### PR TITLE
do not update node positions if user really wants them frozen

### DIFF
--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -252,7 +252,7 @@ export default Kapsule({
             // D3-force
             (layout = state.d3ForceLayout)
                 .stop()
-                .alpha(1)// re-heat the simulation
+                .alpha(state.cooldownTicks <= 0 || state.cooldownTime <= 0 ? 0 : 1)// re-heat the simulation
                 .numDimensions(state.numDimensions)
                 .nodes(state.graphData.nodes)
                 .force('link')


### PR DESCRIPTION
After my graph is stable I have some user actions that need to update the colors of the nodes. This is easy enough to do by sending in new `graphData`, and I set `.cooldownTicks(0)` to make sure the graph doesn't budge. Even so, it does update 1 tick. This diff makes it so that it doesn't even update one tick if the user has specified that she really doesn't want the graph not to move.