### PR TITLE
Add recursive intersections for Raycaster

### DIFF
--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -315,7 +315,7 @@ export default Kapsule({
         raycaster.linePrecision = state.linkHoverPrecision;
 
         raycaster.setFromCamera(mousePos, state.camera);
-        const intersects = raycaster.intersectObjects(state.forceGraph.children)
+        const intersects = raycaster.intersectObjects(state.forceGraph.children, true)
           .filter(o => ['node', 'link'].indexOf(o.object.__graphObjType) !== -1) // Check only node/link objects
           .sort((a, b) => { // Prioritize nodes over links
             const isNode = o => o.object.__graphObjType === 'node';

--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -315,7 +315,8 @@ export default Kapsule({
         raycaster.linePrecision = state.linkHoverPrecision;
 
         raycaster.setFromCamera(mousePos, state.camera);
-        const intersects = raycaster.intersectObjects(state.forceGraph.children, true)
+        const checkObjectDescendants = !!state.nodeThreeObject;
+        const intersects = raycaster.intersectObjects(state.forceGraph.children, checkObjectDescendants)
           .filter(o => ['node', 'link'].indexOf(o.object.__graphObjType) !== -1) // Check only node/link objects
           .sort((a, b) => { // Prioritize nodes over links
             const isNode = o => o.object.__graphObjType === 'node';


### PR DESCRIPTION
*Problem*

`onNodeClick`, `onNodeHover` does not work for custom [Group](https://threejs.org/docs/#api/objects/Group) objects.

------

*Dependency*

https://github.com/vasturiano/three-forcegraph/pull/7

------

*Solution*

Add recursive argument to [Raycaster.intersectObjects](https://threejs.org/docs/#api/core/Raycaster.intersectObjects) for checking intersections with object descendants.

------

*Details*

I am using `nodeThreeObject` to return custom loaded 3D OBJ `xxxx.obj` with `xxxx.mtl`.
It's imported as a Group object with children Mesh objects. Similar results can be achieved by creating Group object and adding Mesh into it.


intersectObjects does not intersect nested objects by default so we need to pass 2d argument as a `true`.

