### PR TITLE
Expose `camera`

### DIFF
--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -109,6 +109,7 @@ export default Kapsule({
       return this;
     },
     scene: state => state.renderObjs.scene(), // Expose scene
+    camera: state => state.renderObjs.camera(), // Expose camera
     ...linkedFGMethods,
     ...linkedRenderObjsMethods
   },


### PR DESCRIPTION
Hey @vasturiano, not sure if this fits in with what you expect library users to have access to, but this was a handy change to allow me to implement the workaround in https://github.com/mrdoob/three.js/issues/13751#issuecomment-385961737.

Let me know if you'd want to pursue this, or if you need anything else from me.

Thanks!