### PR TITLE
Handle resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ myGraph(<myDOMElement>)
 | <b>camera</b>() | Access the internal ThreeJS [Camera](https://threejs.org/docs/#api/cameras/PerspectiveCamera). | |
 | <b>renderer</b>() | Access the internal ThreeJS [WebGL renderer](https://threejs.org/docs/#api/renderers/WebGLRenderer). || 
 | <b>tbControls</b>() | Access the internal ThreeJS [Trackball Controls](https://threejs.org/examples/misc_controls_trackball.html). ||
+| <b>handleResize</b>() | Handles a resize, based on the dimensions of the containing element. ||
 
 ### Force engine configuration 
 | Method | Description | Default |

--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -131,6 +131,14 @@ export default Kapsule({
     camera: state => state.renderObjs.camera(), // Expose camera
     renderer: state => state.renderObjs.renderer(), // Expose renderer
     tbControls: state => state.renderObjs.tbControls(), // Expose tbControls
+    handleResize: function(state) {
+      state.renderObjs.height(state.container.getClientRects()[0].height);
+      state.renderObjs.width(state.container.getClientRects()[0].width);
+
+      state.tbControls.handleResize();
+
+      return this;
+    },
     ...linkedFGMethods,
     ...linkedRenderObjsMethods
   },


### PR DESCRIPTION
Had an issue where resizing the window was not working..

I couldn't see anything obvious that already exists to deal with this, but if there is such a thing, disregard this PR!

Some of what is added can be performed by the caller (eg `state.tbControls.handleResize()`), but access to `renderObjs` is restricted.