### PR TITLE
startAnimation method to resume animation after stopAnimation method has been called

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Check out the examples:
 * [Node collision detection](https://vasturiano.github.io/3d-force-graph/example/collision-detection/) ([source](https://github.com/vasturiano/3d-force-graph/blob/master/example/collision-detection/index.html))
 * [Add external objects to scene](https://vasturiano.github.io/3d-force-graph/example/scene/) ([source](https://github.com/vasturiano/3d-force-graph/blob/master/example/scene/index.html))
 
+* [Stop / Resume animation](https://vasturiano.github.io/3d-force-graph/example/stop-resume/) ([source](https://github.com/vasturiano/3d-force-graph/blob/master/example/stop-resume/index.html))
+
 See also the [VR version](https://github.com/vasturiano/3d-force-graph-vr) and the [2D canvas version](https://github.com/vasturiano/force-graph).
 
 And check out the [React bindings](https://github.com/vasturiano/react-force-graph).
@@ -108,6 +110,7 @@ myGraph(<myDOMElement>)
 | Method | Description | Default |
 | --- | --- | :--: |
 | <b>stopAnimation</b>() | Stops the rendering cycle of the component, effectively freezing the current view and canceling all future user interaction. This method can be used to save performance in circumstances when a static image is sufficient. | |
+| <b>startAnimation</b>() | Starts the rendering cycle of the component, effectively unfreezing the current view and enabling all future user interaction. This method can be used to save performance together with `stopAnimation` method. | |
 | <b>cameraPosition</b>([<i>{x,y,z}</i>], [<i>lookAt</i>], [<i>ms</i>]) | Getter/setter for the camera position, in terms of `x`, `y`, `z` coordinates. Each of the coordinates is optional, allowing for motion in just some dimensions. The optional second argument can be used to define the direction that the camera should aim at, in terms of an `{x,y,z}` point in the 3D space. The 3rd optional argument defines the duration of the transition (in ms) to animate the camera motion. A value of 0 (default) moves the camera immediately to the final position. | By default the camera will face the center of the graph at a `z` distance proportional to the amount of nodes in the system. |
 | <b>scene</b>() | Access the internal ThreeJS [Scene](https://threejs.org/docs/#api/scenes/Scene). Can be used to extend the current scene with additional objects not related to 3d-force-graph. | |
 | <b>camera</b>() | Access the internal ThreeJS [Camera](https://threejs.org/docs/#api/cameras/PerspectiveCamera). | |

--- a/example/stop-resume/index.html
+++ b/example/stop-resume/index.html
@@ -1,0 +1,55 @@
+<head>
+  <style> body { margin: 0; } </style>
+
+  <script src="//unpkg.com/3d-force-graph"></script>
+  <!-- <script src="../../dist/3d-force-graph.js"></script> -->
+</head>
+
+<body>
+  <button id="stop-resume" style="display: block; margin: 20px; height: 30px; width: 100px;">Stop/Resume</button>
+  <div id="3d-graph"></div>
+
+  <script>
+    // Random tree
+    const N = 300;
+    const gData = {
+      nodes: [...Array(N).keys()].map(i => ({ id: i })),
+      links: [...Array(N).keys()]
+        .filter(id => id)
+        .map(id => ({
+          source: id,
+          target: Math.round(Math.random() * (id-1))
+        }))
+    };
+
+    const distance = 1000;
+
+    const Graph = ForceGraph3D()
+      (document.getElementById('3d-graph'))
+        .enableNodeDrag(false)
+        .enableNavigationControls(false)
+        .showNavInfo(false)
+        .cameraPosition({ z: distance })
+        .graphData(gData);
+
+    // camera orbit
+    let angle = 0;
+    setInterval(() => {
+      Graph.cameraPosition({
+        x: distance * Math.sin(angle),
+        z: distance * Math.cos(angle)
+      });
+      angle += Math.PI / 300;
+    }, 10);
+
+    let isActive = true;
+    document.querySelector("#stop-resume").addEventListener("click", () => {
+      if (isActive) {
+        Graph.stopAnimation();
+      } else {
+        Graph.startAnimation();
+      }
+      isActive = !isActive;
+    });
+  </script>
+</body>

--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -127,6 +127,10 @@ export default Kapsule({
       }
       return this;
     },
+    startAnimation: function(state) {
+      state.animate();
+      return this;
+    },
     scene: state => state.renderObjs.scene(), // Expose scene
     camera: state => state.renderObjs.camera(), // Expose camera
     renderer: state => state.renderObjs.renderer(), // Expose renderer
@@ -313,9 +317,8 @@ export default Kapsule({
       });
 
     //
-
     // Kick-off renderer
-    (function animate() { // IIFE
+    (state.animate = function animate() { // IIFE
       if (state.enablePointerInteraction) {
         // reset canvas cursor (override dragControls cursor)
         renderer.domElement.style.cursor = null;

--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -141,7 +141,8 @@ export default Kapsule({
 
   stateInit: () => ({
     forceGraph: new ThreeForceGraph(),
-    renderObjs: ThreeRenderObjects()
+    renderObjs: ThreeRenderObjects(),
+    animate: () => {}
   }),
 
   init: function(domNode, state) {


### PR DESCRIPTION
WebGL 3D animations take a lot of resources and there are some use cases when it will be good to pause animation and then resume it.

I consider pausing animation when user goes to another tab or if user is inactive for some period of time.

I did not find any possibility to resume animation after it was stopped so this PR adds this possibility.
Will be happy to fix / change it if needed.