### PR TITLE
Fire 'pointerup' after re-enabling 'enableNavigationControls' if enabled.

### DIFF
--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -116,6 +116,12 @@ export default Kapsule({
         const controls = state.renderObjs.controls();
         if (controls) {
           controls.enabled = enable;
+          if (controls.enabled === true) {
+            controls.domElement && controls.domElement.ownerDocument && controls.domElement.ownerDocument.dispatchEvent(
+              // simulate mouseup to ensure the controls don't take over after re-enabling 'enableNavigationControls'
+              new PointerEvent('pointerup', { pointerType: 'touch' })
+            );
+          }
         }
       },
       triggerUpdate: false


### PR DESCRIPTION
fix: don't allow controls to takeover after re-enabling 'enableNavigationControls'.

I was experiencing the camera controls being stuck on after re-enable even if the pointer wasn't down. I **think** this fixes that.