### PR TITLE
fixed versions of three.js and spritetext

### DIFF
--- a/example/text-nodes/index.html
+++ b/example/text-nodes/index.html
@@ -1,8 +1,8 @@
 <head>
   <style> body { margin: 0; } </style>
 
-  <script src="//unpkg.com/three"></script>
-  <script src="//unpkg.com/three-spritetext"></script>
+  <script src="//unpkg.com/three@0.160.1/build/three.min.js"></script>
+  <script src="//unpkg.com/three-spritetext@1.8.2/dist/three-spritetext.min.js"></script>
 
   <script src="//unpkg.com/3d-force-graph"></script>
   <!--<script src="../../dist/3d-force-graph.js"></script>-->


### PR DESCRIPTION
Issue: sprite text example was failing because of unpack/three.js loading a cjs script instead of three.min.js (last versions redirects).

Workaround: fixed urls to previous three.js version and spritetext scripts, to keep the example running without major changes.