### PR TITLE
Adding nodePositionUpdate

### DIFF
--- a/src/3d-force-graph.js
+++ b/src/3d-force-graph.js
@@ -40,6 +40,7 @@ const linkedFGProps = Object.assign(...[
   'nodeVisibility',
   'nodeThreeObject',
   'nodeThreeObjectExtend',
+  'nodePositionUpdate',
   'linkSource',
   'linkTarget',
   'linkVisibility',


### PR DESCRIPTION
Heya!

https://github.com/vasturiano/three-forcegraph/pull/34 added nodePositionUpdate as a way to override the way nodes set their positions when simulating.

I've just made a PR to add this into the list for this repo as well.