### PR TITLE
Change the position of camera

### DIFF
--- a/example/click-to-focus/index.html
+++ b/example/click-to-focus/index.html
@@ -16,13 +16,28 @@
         .nodeLabel('id')
         .nodeAutoColorBy('group')
         .onNodeClick(node => {
-          // Aim at node from outside it
-          const distance = 40;
-          const distRatio = 1 + distance/Math.hypot(node.x, node.y, node.z);
+          const camera = Graph.camera();
+          const cameraPos = camera.position;
 
-          const newPos = node.x || node.y || node.z
-            ? { x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio }
-            : { x: 0, y: 0, z: distance }; // special case if node is in (0,0,0)
+          // The distance between the clicked node and the camera
+          const currentDistance = Math.hypot(
+            node.x - cameraPos.x,
+            node.y - cameraPos.y,
+            node.z - cameraPos.z
+          );
+          const presetDistance = 40;
+
+          const distRatio = presetDistance / currentDistance;
+
+          // If the distance between the camera and the clicked node is less than the preset value, do not move the camera
+          const newPos =
+            currentDistance > presetDistance
+              ? {
+                  x: distRatio * cameraPos.x + (1 - distRatio) * node.x,
+                  y: distRatio * cameraPos.y + (1 - distRatio) * node.y,
+                  z: distRatio * cameraPos.z + (1 - distRatio) * node.z,
+                }
+              : cameraPos;
 
           Graph.cameraPosition(
             newPos, // new position


### PR DESCRIPTION
Closes #701

In the example [code](https://github.com/vasturiano/3d-force-graph/blob/master/example/click-to-focus/index.html), the camera flies to the position 40px away from the clicked node on the extension line of the connection from (0,0,0) to the clicked node.
**Before behavior**
![Screen Recording 2025-02-01 at 17 11 35(1)](https://github.com/user-attachments/assets/89681b8d-5ba3-41f2-8643-97e0d7ef9b81)

While in this PR, the camera just flies towards the clicked node to the position 40px away from it. **The angle of view does not change unnecessarily as before.** You can see more details in [Sandbox](https://codesandbox.io/p/sandbox/3d-force-5hqs87?file=%2Findex.html%3A7%2C8).
**The PR  behavior**
![Screen Recording 2025-02-01 at 20 52 08](https://github.com/user-attachments/assets/63a2bed9-9c8b-47e3-bc07-0e7eb3dcab9c)

I don't have extensive experience creating PRs, so I'd be happy to receive any feedback you might have.