### PR TITLE
Export NodeObject and LinkObject types from three-forcegraph

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -88,3 +88,6 @@ interface IForceGraph3D<NodeType extends NodeObject = NodeObject, LinkType exten
 declare const ForceGraph3D: IForceGraph3D;
 
 export default ForceGraph3D;
+
+// Re-export useful types from three-forcegraph for user convenience
+export { NodeObject, LinkObject } from 'three-forcegraph';


### PR DESCRIPTION
## Problem Summary

**Issue:** Cannot import `NodeObject` and `LinkObject` types from 3d-force-graph
**Impact:** High - Prevents proper TypeScript typing for nodes and links  
**Root Cause:** Missing type re-exports from the `three-forcegraph` dependency

## Technical Analysis

Users were unable to import the fundamental `NodeObject` and `LinkObject` types needed for proper TypeScript development with 3d-force-graph. While these types existed in the `three-forcegraph` dependency and were used internally, they weren't re-exported for external consumption.

### Before Fix
```typescript
// This would fail with TS2305: Module has no exported member 'NodeObject'
import { NodeObject, LinkObject } from '3d-force-graph';

interface CustomNode extends NodeObject {
  id: string;
  name: string;
}
```

### Issue Impact
- Developers couldn't extend base node/link types
- No way to properly type custom graph data structures  
- Had to resort to `any` types or manual type definitions
- Blocked proper TypeScript integration

## Solution Implemented

### 1. Added Type Re-exports

Added explicit re-exports of `NodeObject` and `LinkObject` types from `three-forcegraph` in `src/index.d.ts`:

```typescript
// Re-export useful types from three-forcegraph for user convenience
export { NodeObject, LinkObject } from 'three-forcegraph';
```

### 2. Verified Fix

- **Build Test:** `yarn build` completed successfully
- **TypeScript Test:** Created comprehensive test validating type imports and usage
- **Type Extensions:** Confirmed custom interfaces can extend base types

## Testing Performed

### TypeScript Import Test
```typescript
import ForceGraph3D, { NodeObject, LinkObject } from '3d-force-graph';

// Custom node interface extending NodeObject
interface CustomNode extends NodeObject {
  id: string;
  name: string;
  group: number;
  value?: number;
}

// Custom link interface extending LinkObject  
interface CustomLink extends LinkObject<CustomNode> {
  source: string | CustomNode;
  target: string | CustomNode;
  value: number;
  label?: string;
}
```

✅ **Result:** Compiles without TypeScript errors

## Impact

### Before Fix
```typescript
// ERROR: Cannot import NodeObject, LinkObject
import { NodeObject, LinkObject } from '3d-force-graph'; // ❌ TS2305

// Developers had to use any or create their own types
interface MyNode {
  // Manual type definition required
}
```

### After Fix
```typescript
// SUCCESS: Types can be imported and extended
import { NodeObject, LinkObject } from '3d-force-graph'; // ✅ Works

interface CustomNode extends NodeObject {
  id: string;
  name: string;
  customProperty: any;
}

interface CustomLink extends LinkObject<CustomNode> {
  weight: number;
  type: string;
}

// Full type safety in graph usage
const graph = new ForceGraph3D(element)
  .graphData({ nodes: customNodes, links: customLinks })
  .nodeLabel((node: CustomNode) => node.name); // ✅ Fully typed
```

## Benefits

1. **Improved Developer Experience**: Proper TypeScript support for graph data
2. **Type Safety**: Full IntelliSense and compile-time checking  
3. **Code Reusability**: Base types can be extended for custom implementations
4. **Documentation**: Types serve as living documentation of expected data structure
5. **Error Prevention**: Catch type mismatches at compile time

## Deployment Notes

1. **Breaking Change:** None - this is a pure additive change
2. **Runtime Impact:** None - only TypeScript definition changes
3. **Compatibility:** Improves TypeScript compatibility without affecting JavaScript usage

Fix #693